### PR TITLE
feat(openai-provider): add reasoning mode for specific models

### DIFF
--- a/docs/text-provider.md
+++ b/docs/text-provider.md
@@ -29,7 +29,9 @@ The API accepts both JSON and multipart form data formats.
   "maxTokens": 100,
   "model": "string",
   "show_stats": false,
-  "stream": false
+  "stream": false,
+  "web_search": false,
+  "reasoning": false
 }
 ```
 
@@ -46,6 +48,8 @@ The API accepts both JSON and multipart form data formats.
 | model              | string  | No       | Specific model to use                                  |
 | show_stats         | boolean | No       | Whether to return model and usage statistics           |
 | stream             | boolean | No       | Whether to stream the response as Server-Sent Events   |
+| web_search         | boolean | No       | Whether to perform web search based response           |
+| reasoning          | boolean | No       | Whether to show reasoning process                      |
 
 #### Multipart Form Data
 

--- a/src/__tests__/openai-provider.test.ts
+++ b/src/__tests__/openai-provider.test.ts
@@ -11,7 +11,163 @@ describe('OpenAIProvider', () => {
     provider = new OpenAIProvider(process.env.OPENAI_API_KEY || 'test-api-key');
   });
 
+  // Test text models with various input combinations
+  const textModels = [
+    'o1',
+    'o1-mini',
+    'o3-mini',
+    'chatgpt-4o-latest',
+    'gpt-3.5-turbo',
+    'gpt-3.5-turbo-16k',
+    'gpt-4-turbo',
+    'gpt-4',
+    'gpt-4o',
+    'gpt-4o-mini',
+  ];
+
+  const visionModels = ['gpt-4-turbo'];
+  const webSearchModels = ['gpt-4o-search-preview', 'gpt-4o-mini-search-preview'];
+  const audioModels = ['whisper-1'];
+
+  // Test cases for different input types and scenarios
+  const testCases = {
+    text: [
+      { description: 'simple question', content: 'What is the capital of France?' },
+      {
+        description: 'code analysis',
+        content: 'Explain this code: function add(a,b) { return a + b; }',
+      },
+      {
+        description: 'long context',
+        content: 'Write a small paragraph about artificial intelligence in 50 words',
+      },
+    ],
+    reasoning: [
+      { description: 'math problem', content: 'If x=5 and y=3, what is x^2 + y^2?' },
+      {
+        description: 'logic puzzle',
+        content:
+          'A says B is lying. B says C is lying. C says A is telling the truth. Who is lying?',
+      },
+    ],
+    webSearch: [
+      {
+        description: 'current events',
+        content: 'What are the latest developments in quantum computing?',
+      },
+      {
+        description: 'technical query',
+        content: 'Explain the differences between various blockchain consensus mechanisms.',
+      },
+    ],
+  };
+
   (hasOpenAIKey ? describe : describe.skip)('getCompletion', () => {
+    // Test text completion with various scenarios for all text models
+    textModels.forEach(model => {
+      // Test different text completion scenarios
+      testCases.text.forEach(testCase => {
+        test(`${model} handles ${testCase.description}`, async () => {
+          const request: AICompletionRequest = {
+            model,
+            messages: [{ role: 'user', content: testCase.content }],
+          };
+
+          const response = await provider.getCompletion(request);
+          expect(response.model).toContain(model);
+        }, 60000);
+      });
+
+      // Test with system message
+      test(`${model} handles system message`, async () => {
+        const request: AICompletionRequest = {
+          model,
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful assistant that speaks like Shakespeare.',
+            },
+            { role: 'user', content: 'How are you?' },
+          ],
+        };
+
+        if (['o1', 'o1-mini', 'o3-mini'].includes(model)) {
+          await expect(provider.getCompletion(request)).rejects.toThrow(
+            "'messages[0].role' does not support 'system' with this model"
+          );
+        } else {
+          const response = await provider.getCompletion(request);
+          expect(response.model).toContain(model);
+          expect(response.content).toBeTruthy();
+          expect(response.content.length).toBeGreaterThan(0);
+        }
+      }, 60000);
+
+      test(`${model} handles reasoning mode`, async () => {
+        const request: AICompletionRequest = {
+          model,
+          messages: [{ role: 'user', content: 'What is 2+2?' }],
+          reasoning: true,
+        };
+
+        if (!['o1', 'o3-mini'].includes(model)) {
+          await expect(provider.getCompletion(request)).rejects.toThrow(
+            'Reasoning is not supported for models other than o1, o3-mini.'
+          );
+        } else {
+          const response = await provider.getCompletion(request);
+          expect(response.content).toBeTruthy();
+          expect(() => JSON.parse(response.content)).not.toThrow();
+        }
+      }, 60000);
+    });
+
+    // Test vision capabilities
+    visionModels.forEach(model => {
+      test(`${model} handles image input`, async () => {
+        const testImagePath = new URL('./data-sources/text-based-image.png', import.meta.url);
+        const bunFile = Bun.file(testImagePath);
+        const imageFile = new File([await bunFile.arrayBuffer()], 'text-based-image.png', {
+          type: 'image/png',
+        });
+        const request: AICompletionRequest = {
+          model,
+          messages: [{ role: 'user', content: 'Describe this image' }],
+          input_file: imageFile,
+        };
+
+        const response = await provider.getCompletion(request);
+        expect(response.content).toBeTruthy();
+      }, 60000);
+    });
+
+    // Test web search capabilities
+    webSearchModels.forEach(model => {
+      test(`${model} handles web search`, async () => {
+        const request: AICompletionRequest = {
+          model,
+          messages: [{ role: 'user', content: 'What is the latest news about AI?' }],
+          web_search: true,
+        };
+
+        const response = await provider.getCompletion(request);
+        expect(response.content).toBeTruthy();
+      }, 60000);
+
+      test(`${model} handles web search in streaming mode`, async () => {
+        const request: AICompletionRequest = {
+          model,
+          messages: [{ role: 'user', content: 'What is the latest news about AI?' }],
+          web_search: true,
+          stream: true,
+        };
+
+        const generator = provider.getCompletionStream(request);
+        const firstChunk = (await generator.next()).value;
+        expect(firstChunk.content).toBeDefined();
+      }, 60000);
+    });
+
     test('rejects txt files in input_file', async () => {
       const testTxtPath = new URL('./data-sources/test.txt', import.meta.url);
       const bunFile = Bun.file(testTxtPath);
@@ -26,7 +182,7 @@ describe('OpenAIProvider', () => {
       await expect(provider.getCompletion(request)).rejects.toThrow(
         'Only supports image files (PNG, JPEG, and WEBP)'
       );
-    });
+    }, 60000);
 
     test('rejects gif files in input_file', async () => {
       const testGifPath = new URL('./data-sources/test.gif', import.meta.url);
@@ -42,7 +198,7 @@ describe('OpenAIProvider', () => {
       await expect(provider.getCompletion(request)).rejects.toThrow(
         'Only supports image files (PNG, JPEG, and WEBP)'
       );
-    });
+    }, 60000);
 
     test('uses default model when not specified', async () => {
       const request: AICompletionRequest = {
@@ -51,7 +207,7 @@ describe('OpenAIProvider', () => {
 
       const response = await provider.getCompletion(request);
       expect(response.model).toBe('gpt-3.5-turbo-0125');
-    });
+    }, 60000);
 
     test('maps assistant role to model role', async () => {
       const request: AICompletionRequest = {
@@ -63,7 +219,7 @@ describe('OpenAIProvider', () => {
 
       const response = await provider.getCompletion(request);
       expect(response.provider).toBe('openai');
-    }, 10000);
+    }, 30000);
 
     test('handles input_file in request', async () => {
       const testImagePath = new URL('./data-sources/text-based-image.png', import.meta.url);
@@ -80,7 +236,7 @@ describe('OpenAIProvider', () => {
       const response = await provider.getCompletion(request);
       expect(response.provider).toBe('openai');
       expect(response.content).toBeTruthy();
-    }, 10000); // Increase timeout to 10 seconds for image processing
+    }, 30000); // Increase timeout to 30 seconds for image processing
 
     test('handles temperature parameter', async () => {
       const request: AICompletionRequest = {
@@ -90,7 +246,7 @@ describe('OpenAIProvider', () => {
 
       const response = await provider.getCompletion(request);
       expect(response.provider).toBe('openai');
-    });
+    }, 10000);
 
     test('handles maxTokens parameter', async () => {
       const request: AICompletionRequest = {
@@ -100,7 +256,7 @@ describe('OpenAIProvider', () => {
 
       const response = await provider.getCompletion(request);
       expect(response.provider).toBe('openai');
-    });
+    }, 10000);
 
     test('shows usage stats when requested', async () => {
       const request: AICompletionRequest = {
@@ -113,7 +269,7 @@ describe('OpenAIProvider', () => {
       expect(response.usage).toHaveProperty('promptTokens');
       expect(response.usage).toHaveProperty('completionTokens');
       expect(response.usage).toHaveProperty('totalTokens');
-    });
+    }, 10000);
 
     test('handles web_search parameter', async () => {
       const request: AICompletionRequest = {
@@ -129,17 +285,20 @@ describe('OpenAIProvider', () => {
   });
 
   (hasOpenAIKey ? describe : describe.skip)('getCompletionStream', () => {
-    test('yields chunks with correct structure', async () => {
-      const request: AICompletionRequest = {
-        messages: [{ role: 'user', content: 'Hello' }],
-      };
+    // Test streaming for all text models
+    textModels.forEach(model => {
+      test(`${model} handles streaming`, async () => {
+        const request: AICompletionRequest = {
+          model,
+          messages: [{ role: 'user', content: 'Hello' }],
+          stream: true,
+        };
 
-      const generator = provider.getCompletionStream(request);
-      const firstChunk = (await generator.next()).value;
-
-      expect(firstChunk).toHaveProperty('content');
-      expect(firstChunk).toHaveProperty('model');
-      expect(firstChunk).toHaveProperty('provider', 'openai');
+        const generator = provider.getCompletionStream(request);
+        const firstChunk = (await generator.next()).value;
+        expect(firstChunk.model).toContain(model);
+        expect(firstChunk.content).toBeDefined();
+      }, 60000);
     });
 
     test('handles web_search parameter in streaming mode', async () => {
@@ -156,7 +315,7 @@ describe('OpenAIProvider', () => {
       expect(firstChunk).toHaveProperty('provider', 'openai');
       // Note: We can't reliably test for search_results as it depends on OpenAI's response
       // and whether the model actually performs a search in the first chunk
-    }, 10000);
+    }, 60000);
 
     test('handles input_file in stream request', async () => {
       const testImagePath = new URL('./data-sources/text-based-image.png', import.meta.url);
@@ -176,7 +335,7 @@ describe('OpenAIProvider', () => {
 
       expect(firstChunk).toHaveProperty('content');
       expect(firstChunk).toHaveProperty('provider', 'openai');
-    }, 10000); // Increase timeout to 10 seconds for image processing
+    }, 60000); // Increase timeout to 60 seconds for image processing
   });
 
   test('returns available models with correct structure', async () => {
@@ -205,6 +364,64 @@ describe('OpenAIProvider', () => {
   });
 
   describe('transcribeAudio', () => {
+    // Test audio transcription capabilities for all audio models
+    audioModels.forEach(model => {
+      (hasOpenAIKey ? test : test.skip)(
+        `${model} handles audio transcription`,
+        async () => {
+          const audioPath = new URL('./data-sources/sample-audio.mp3', import.meta.url);
+          const bunFile = Bun.file(audioPath);
+          const audioFile = new File([await bunFile.arrayBuffer()], 'sample-audio.mp3', {
+            type: 'audio/mpeg',
+          });
+          const request: AIAudioTranscriptionRequest = {
+            model,
+            input_file: audioFile,
+          };
+
+          const response = await provider.transcribeAudio(request);
+          expect(response.transcription).toBeTruthy();
+        },
+        60000
+      );
+    });
+
+    // Test invalid model combinations
+    (hasOpenAIKey ? test : test.skip)(
+      'rejects audio model for text completion',
+      async () => {
+        const request: AICompletionRequest = {
+          model: 'whisper-1',
+          messages: [{ role: 'user', content: 'Hello' }],
+        };
+
+        await expect(provider.getCompletion(request)).rejects.toThrow(
+          'Invalid model used. Use /provider/models api to know which models are supported'
+        );
+      },
+      60000
+    );
+
+    (hasOpenAIKey ? test : test.skip)(
+      'rejects text model for audio transcription',
+      async () => {
+        const audioPath = new URL('./data-sources/sample-audio.mp3', import.meta.url);
+        const bunFile = Bun.file(audioPath);
+        const audioFile = new File([await bunFile.arrayBuffer()], 'sample-audio.mp3', {
+          type: 'audio/mpeg',
+        });
+        const request: AIAudioTranscriptionRequest = {
+          model: 'gpt-4',
+          input_file: audioFile,
+        };
+
+        await expect(provider.transcribeAudio(request)).rejects.toThrow(
+          'Invalid model used. Use /provider/models api to know which models are supported'
+        );
+      },
+      60000
+    );
+
     (hasOpenAIKey ? test : test.skip)(
       'successfully transcribes audio file',
       async () => {

--- a/src/routes/completion.ts
+++ b/src/routes/completion.ts
@@ -55,6 +55,7 @@ export const createCompletionRoutes = (providers: Map<string, AIProvider>) => {
         show_stats: body.show_stats,
         input_file: body.input_file,
         web_search: body.web_search,
+        reasoning: body.reasoning,
       };
 
       if (body.stream && provider.getCompletionStream) {

--- a/src/types/ai-provider.ts
+++ b/src/types/ai-provider.ts
@@ -30,6 +30,7 @@ export interface AICompletionRequest {
   show_stats?: boolean;
   input_file?: File;
   web_search?: boolean;
+  reasoning?: boolean;
 }
 
 export interface AICompletionResponse {

--- a/src/validators/completion.ts
+++ b/src/validators/completion.ts
@@ -15,4 +15,5 @@ export const completionSchema = z.object({
   stream: z.boolean().optional().default(false),
   input_file: z.instanceof(File).optional(),
   web_search: z.boolean().optional().default(false),
+  reasoning: z.boolean().optional().default(false),
 });


### PR DESCRIPTION
Introduce a new `reasoning` option in the AI completion request to enable JSON-formatted responses for specific models (o1, o1-mini, o3-mini). This includes validation, system message handling, and updated test cases to ensure compatibility and functionality.